### PR TITLE
Multiple soundfonts feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ endif
 ###############################################################################
 
 BUILDDIR = build/
+SOUNDFONTSDIR = soundfonts/
 
 ###############################################################################
 
@@ -67,7 +68,12 @@ endif
 
 targets+=$(BUILDDIR)$(LV2NAME)$(LIB_EXT)
 
-targets+=$(BUILDDIR)GeneralUser_LV2.sf2
+SF2_FILES := $(notdir $(wildcard sf2/*.sf2))
+targets += $(addprefix $(BUILDDIR)$(SOUNDFONTSDIR),$(SF2_FILES))
+
+PY_FILES  := $(notdir $(wildcard python_scripts/*.py))
+targets += $(addprefix $(BUILDDIR),$(PY_FILES))
+
 
 ###############################################################################
 # extract versions
@@ -127,8 +133,12 @@ $(BUILDDIR)$(LV2NAME).ttl: Makefile lv2ttl/$(LV2NAME).*.in
 	sed "s/@LV2NAME@/$(LV2NAME)/;s/@VERSION@/lv2:microVersion $(LV2MIC) ;lv2:minorVersion $(LV2MIN) ;/g" \
 		lv2ttl/$(LV2NAME).ttl.in > $(BUILDDIR)$(LV2NAME).ttl
 
-$(BUILDDIR)%.sf2: sf2/*.sf2
-	cp -v sf2/$(*F).sf2 $@
+$(BUILDDIR)$(SOUNDFONTSDIR)%.sf2: sf2/%.sf2
+	@mkdir -p $(dir $@)
+	cp -v $< $@
+
+$(BUILDDIR)%.py: python_scripts/%.py
+	cp -v $< $@
 
 FLUID_SRC = \
             fluidsynth/src/fluid_adsr_env.c \
@@ -182,26 +192,20 @@ $(BUILDDIR)$(LV2GUI)$(LIB_EXT): gui/$(LV2NAME).c
 
 install: all
 	install -d $(DESTDIR)$(LV2DIR)/$(BUNDLE)
-	install -m644 $(BUILDDIR)manifest.ttl $(BUILDDIR)$(LV2NAME).ttl $(BUILDDIR)*.sf2 $(DESTDIR)$(LV2DIR)/$(BUNDLE)
-	install -m755 $(BUILDDIR)$(LV2NAME)$(LIB_EXT) $(DESTDIR)$(LV2DIR)/$(BUNDLE)
+	cp -vr $(BUILDDIR)* $(DESTDIR)$(LV2DIR)/$(BUNDLE)/
+	find $(DESTDIR)$(LV2DIR)/$(BUNDLE) -type f -exec chmod 644 {} +
+	chmod 755 $(DESTDIR)$(LV2DIR)/$(BUNDLE)/$(LV2NAME)$(LIB_EXT)
+	python $(DESTDIR)$(LV2DIR)/$(BUNDLE)/scan_soundfonts.py
 
 uninstall:
-	rm -f $(DESTDIR)$(LV2DIR)/$(BUNDLE)/manifest.ttl
-	rm -f $(DESTDIR)$(LV2DIR)/$(BUNDLE)/$(LV2NAME).ttl
-	rm -f $(DESTDIR)$(LV2DIR)/$(BUNDLE)/*.sf2
-	rm -f $(DESTDIR)$(LV2DIR)/$(BUNDLE)/$(LV2NAME)$(LIB_EXT)
-	-rmdir $(DESTDIR)$(LV2DIR)/$(BUNDLE)
+	rm -r $(DESTDIR)$(LV2DIR)/$(BUNDLE)
 
 install-man:
 
 uninstall-man:
 
 clean:
-	rm -f $(BUILDDIR)manifest.ttl $(BUILDDIR)$(LV2NAME).ttl \
-	  $(BUILDDIR)$(LV2NAME)$(LIB_EXT) \
-	  $(BUILDDIR)*.sf2
-	rm -rf $(BUILDDIR)*.dSYM
-	-test -d $(BUILDDIR) && rmdir $(BUILDDIR) || true
+	rm -r $(BUILDDIR)
 
 distclean: clean
 	rm -f cscope.out cscope.files tags

--- a/python_scripts/scan_soundfonts.py
+++ b/python_scripts/scan_soundfonts.py
@@ -1,0 +1,209 @@
+# ------------------------------------------------------------------------------
+# libraries
+# ------------------------------------------------------------------------------
+
+import os
+import re
+
+# ------------------------------------------------------------------------------
+# types
+# ------------------------------------------------------------------------------
+
+class Plugin:
+    folder: str
+    name: str
+    extension: str
+    version: str
+
+# ------------------------------------------------------------------------------
+# constants
+# ------------------------------------------------------------------------------
+
+PLUGIN_NAME = 'gmsynth'
+
+MANIFEST_TTL_HEADER = (
+    f'@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .{os.linesep}'
+    f'@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .{os.linesep}'
+    f'@prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .{os.linesep}'
+)
+
+MANIFEST_TTL_MODULE = (
+    f'<http://gareus.org/oss/lv2/@LV2NAME@#@SOUNDFONT@>{os.linesep}'
+    f'	a lv2:Plugin ;{os.linesep}'
+    f'	lv2:binary <@LV2NAME@@LIB_EXT@>  ;{os.linesep}'
+    f'	rdfs:seeAlso <@LV2NAME@.ttl> .{os.linesep}'
+)
+
+GMSYNTH_TTL_HEADER = (
+    f'@prefix atom:  <http://lv2plug.in/ns/ext/atom#> .{os.linesep}'
+    f'@prefix doap:  <http://usefulinc.com/ns/doap#> .{os.linesep}'
+    f'@prefix foaf:  <http://xmlns.com/foaf/0.1/> .{os.linesep}'
+    f'@prefix lv2:   <http://lv2plug.in/ns/lv2core#> .{os.linesep}'
+    f'@prefix midi:  <http://lv2plug.in/ns/ext/midi#> .{os.linesep}'
+    f'@prefix pprop: <http://lv2plug.in/ns/ext/port-props#> .{os.linesep}'
+    f'@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .{os.linesep}'
+    f'@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .{os.linesep}'
+    f'@prefix state: <http://lv2plug.in/ns/ext/state#> .{os.linesep}'
+    f'@prefix ui:    <http://lv2plug.in/ns/extensions/ui#> .{os.linesep}'
+    f'@prefix urid:  <http://lv2plug.in/ns/ext/urid#> .{os.linesep}'
+    f'{os.linesep}'
+    f'<http://ardour.org/lv2/midnam#interface> a lv2:ExtensionData .{os.linesep}'
+    f'<http://ardour.org/lv2/midnam#update> a lv2:Feature .{os.linesep}'
+    f'<http://ardour.org/lv2/bankpatch#notify> a lv2:Feature .{os.linesep}'
+    f'{os.linesep}'
+    f'<http://gareus.org/rgareus#me>{os.linesep}'
+    f'	a foaf:Person ;{os.linesep}'
+    f'	foaf:name "Robin Gareus" ;{os.linesep}'
+    f'	foaf:mbox <mailto:robin@gareus.org> ;{os.linesep}'
+    f'	foaf:homepage <http://gareus.org/> .{os.linesep}'
+)
+
+GMSYNTH_TTL_MODULE = (
+    f'<http://gareus.org/oss/lv2/@LV2NAME@#@SOUNDFONT@> {os.linesep}'
+    f'  a doap:Project, lv2:InstrumentPlugin, lv2:Plugin ; {os.linesep}'
+    f'  doap:name "gmsynth @SOUNDFONT@" ; {os.linesep}'
+    f'  doap:maintainer <http://gareus.org/rgareus#me>; {os.linesep}'
+    f'  doap:license <http://usefulinc.com/doap/licenses/gpl> ; {os.linesep}'
+    f'  @VERSION@ {os.linesep}'
+    f'  lv2:requiredFeature urid:map; {os.linesep}'
+    f'  lv2:optionalFeature lv2:hardRTCapable; {os.linesep}'
+    f'	lv2:optionalFeature <http://ardour.org/lv2/midnam#update>; {os.linesep}'
+    f'	lv2:optionalFeature <http://ardour.org/lv2/bankpatch#notify>; {os.linesep}'
+    f'	lv2:extensionData <http://ardour.org/lv2/midnam#interface>; {os.linesep}'
+    f'  lv2:port [ {os.linesep}'
+    f'      a lv2:InputPort, atom:AtomPort ; {os.linesep}'
+    f'      atom:bufferType atom:Sequence ; {os.linesep}'
+    f'      atom:supports midi:MidiEvent; {os.linesep}'
+    f'      lv2:designation lv2:control ; {os.linesep}'
+    f'      lv2:index 0 ; {os.linesep}'
+    f'      lv2:symbol "control" ; {os.linesep}'
+    f'      lv2:name "Midi In" ; {os.linesep}'
+    f'  ] , [ {os.linesep}'
+    f'      a lv2:OutputPort, lv2:AudioPort ; {os.linesep}'
+    f'      lv2:index 1 ; {os.linesep}'
+    f'      lv2:symbol "outL" ; {os.linesep}'
+    f'      lv2:name "Output Left" ; {os.linesep}'
+    f'  ] , [ {os.linesep}'
+    f'      a lv2:OutputPort, lv2:AudioPort ; {os.linesep}'
+    f'      lv2:index 2 ; {os.linesep}'
+    f'      lv2:symbol "outR" ; {os.linesep}'
+    f'      lv2:name "Output Right" ; {os.linesep}'
+    f'  ] . {os.linesep}'
+)
+
+# ------------------------------------------------------------------------------
+# main function
+# ------------------------------------------------------------------------------
+
+def main() -> None:
+
+    plugin = Plugin()
+    plugin.folder = get_plugin_bundle_path()
+    plugin.name = PLUGIN_NAME
+    plugin.extension = get_plugin_extension(plugin.folder)
+    plugin.version = get_plugin_version(plugin.folder)
+
+    sf2_folder: str = os.path.join(plugin.folder, 'soundfonts')
+    sanitize_sf2_filenames(sf2_folder)
+    sf2_list: list[str] = get_sf2_list(sf2_folder)
+
+    manifest_content: str = compile_template(MANIFEST_TTL_HEADER, plugin)
+    manifest_content += os.linesep
+    
+    gmsynth_content: str = compile_template(GMSYNTH_TTL_HEADER, plugin)
+    gmsynth_content += os.linesep
+    
+    soundfonts_list: str = ''
+
+    manifest_module = compile_template(MANIFEST_TTL_MODULE, plugin)
+    gmsynth_module = compile_template(GMSYNTH_TTL_MODULE, plugin)
+
+    for sf2_file in sf2_list:
+
+        manifest_content += manifest_module.replace('@SOUNDFONT@', sf2_file)
+        manifest_content += os.linesep
+        
+        gmsynth_content += gmsynth_module.replace('@SOUNDFONT@', sf2_file)
+        gmsynth_content += os.linesep
+        
+        soundfonts_list += sf2_file
+        soundfonts_list += os.linesep
+
+    write_to_file(os.path.join(plugin.folder, 'manifest.ttl'), manifest_content)
+    write_to_file(os.path.join(plugin.folder, f'{PLUGIN_NAME}.ttl'), gmsynth_content)
+    write_to_file(os.path.join(plugin.folder, 'soundfonts_list.txt'), soundfonts_list)
+
+    console_log('Finished.')
+
+# ------------------------------------------------------------------------------
+# auxiliary functions
+# ------------------------------------------------------------------------------
+
+def console_log(data: str) -> None:
+    print(data)
+
+def get_plugin_bundle_path() -> str:
+    this_script = os.path.realpath(__file__)
+    bundle_path = os.path.dirname(this_script)
+    console_log(f'Plugin path is "{bundle_path}"')
+    return bundle_path
+
+def get_plugin_extension(folder_path: str) -> str:
+    extension = ''
+    files_list: list[str] = os.listdir(folder_path)
+    for file in files_list:
+        if file.startswith(PLUGIN_NAME) and not file.endswith('.ttl'):
+            extension = file.replace(PLUGIN_NAME, '')
+            break
+    console_log(f'Plugin extension is "{extension}"')
+    return extension
+
+def get_plugin_version(folder_path: str) -> str:
+    version = ''
+    with open(os.path.join(folder_path, f'{PLUGIN_NAME}.ttl')) as file:
+        for line in file:
+            data = line.strip()
+            if 'lv2:microVersion' in data or 'lv2:minorVersion' in data:
+                version = data
+                break
+    console_log(f'Plugin version is "{version}"')
+    return version
+
+def get_sf2_list(folder_path: str) -> list[str]:
+    files_list: list[str] = os.listdir(folder_path)
+    sf2_list: list[str] = []
+    for file in files_list:
+        if file.endswith('.sf2'):
+            console_log(f'Found soundfont "{file}"')
+            sf2_list.append(file)
+    return sf2_list
+
+def compile_template(template: str, plug_data: Plugin) -> str:
+    out = template
+    out = out.replace('@LV2NAME@', plug_data.name)
+    out = out.replace('@LIB_EXT@', plug_data.extension)
+    out = out.replace('@VERSION@', plug_data.version)
+    return out
+
+def write_to_file(path: str, data: str) -> None:
+    with open(path, "wb") as file:
+        file.write(data.encode("utf-8"))
+    console_log(f'Written file {path}')
+
+def sanitize_sf2_filenames(path: str) -> None:
+    valid_chars = re.compile(r"[^A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=]")
+    for root, _, files in os.walk(path):
+        for name in files:
+            if name.endswith('.sf2'):
+                sanitized = valid_chars.sub('_', name)
+                if sanitized != name:
+                    old_path = os.path.join(root, name)
+                    new_path = os.path.join(root, sanitized)
+                    os.rename(old_path, new_path)
+                    console_log(f'Sanitized "{name}" into "{sanitized}"')
+
+# ------------------------------------------------------------------------------
+# runner
+# ------------------------------------------------------------------------------
+
+main()

--- a/src/gmsynth.c
+++ b/src/gmsynth.c
@@ -26,6 +26,7 @@
 #include <math.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <ctype.h>
 
 #define GFS_URN "http://gareus.org/oss/lv2/gmsynth"
 
@@ -49,6 +50,8 @@
 #include "bankpatch_lv2.h"
 
 #include "fluidsynth.h"
+
+#define PATH_SIZE_MAX 1024
 
 #ifdef _WIN32
 #define PATH_SEP "\\"
@@ -256,6 +259,15 @@ load_sf2 (GFSSynth* self, const char* fn)
 	return true;
 }
 
+static void build_plugin_uri(char *dest, const char *identifier)
+{
+	int written = snprintf(dest, PATH_SIZE_MAX, "%s#%s", GFS_URN, identifier);
+
+	if (written < 0 || written >= PATH_SIZE_MAX) {
+		dest[PATH_SIZE_MAX - 1] = '\0';
+	}
+}
+
 static int file_exists (const char *filename) {
 	struct stat s;
 	if (!filename || strlen(filename) < 1) return 0;
@@ -263,6 +275,50 @@ static int file_exists (const char *filename) {
 	if (result != 0) return 0; /* stat() failed */
 	if (S_ISREG(s.st_mode)) return 1; /* is a regular file - ok */
 	return 0;
+}
+
+static void trim_whitespaces(char *str)
+{
+	char *end;
+
+	while (isspace((unsigned char)*str))
+		str++;
+
+	if (*str == 0)
+	{
+		*str = '\0';
+		return;
+	}
+
+	end = str + strlen(str) - 1;
+	while (end > str && isspace((unsigned char)*end))
+		end--;
+
+	*(end + 1) = '\0';
+}
+
+static uint32_t count_non_empty_lines(const char *filepath)
+{
+	FILE *file = fopen(filepath, "r");
+	if (!file)
+	{
+		return 0;
+	}
+
+	char line[PATH_SIZE_MAX];
+	uint32_t count = 0;
+
+	while (fgets(line, sizeof(line), file))
+	{
+		trim_whitespaces(line);
+		if (line[0] != '\0')
+		{
+			count++;
+		}
+	}
+
+	fclose(file);
+	return count;
 }
 
 /* *****************************************************************************
@@ -303,8 +359,24 @@ instantiate (const LV2_Descriptor*     descriptor,
 		return NULL;
 	}
 
-	char sf2_file_path[1024];
-	snprintf (sf2_file_path, sizeof (sf2_file_path), "%s" PATH_SEP "GeneralUser_LV2.sf2", bundle_path);
+	char sf2_file_path[PATH_SIZE_MAX];
+
+	const char *soundfont_file_name = descriptor->URI;
+	bool found_file_name_start = false;
+	while (!found_file_name_start && *soundfont_file_name)
+	{
+		if ('#' == *soundfont_file_name)
+		{
+			found_file_name_start = true;
+		}
+		soundfont_file_name++;
+	}
+
+	snprintf(
+		sf2_file_path, sizeof(sf2_file_path),
+		"%s" PATH_SEP "soundfonts" PATH_SEP "%s",
+		bundle_path, soundfont_file_name);
+
 	sf2_file_path[sizeof(sf2_file_path) - 1] = '\0';
 
 	if (!file_exists (sf2_file_path)) {
@@ -734,16 +806,33 @@ extension_data (const char* uri)
 	return NULL;
 }
 
-static const LV2_Descriptor descriptor = {
-	GFS_URN,
-	instantiate,
-	connect_port,
-	NULL,
-	run,
-	deactivate,
-	cleanup,
-	extension_data
+static void library_cleanup(LV2_Lib_Handle handle)
+{
+	if (handle)
+	{
+		free(handle);
+	}
+}
+
+static const LV2_Descriptor*
+library_get_plugin(LV2_Lib_Handle handle, uint32_t index)
+{
+	LV2_Descriptor *library = (LV2_Descriptor*) handle;
+	return &(library[index]);
+}
+
+static const LV2_Descriptor DESCRIPTOR_PROTOTYPE = {
+	.URI = NULL,
+	.instantiate = instantiate,
+	.connect_port = connect_port,
+	.activate = NULL,
+	.run = run,
+	.deactivate = deactivate,
+	.cleanup = cleanup,
+	.extension_data = extension_data
 };
+
+static LV2_Lib_Descriptor lib_descriptor;
 
 #undef LV2_SYMBOL_EXPORT
 #ifdef _WIN32
@@ -751,14 +840,68 @@ static const LV2_Descriptor descriptor = {
 #else
 #    define LV2_SYMBOL_EXPORT  __attribute__ ((visibility ("default")))
 #endif
+
+
 LV2_SYMBOL_EXPORT
-const LV2_Descriptor*
-lv2_descriptor (uint32_t index)
+const LV2_Lib_Descriptor *
+lv2_lib_descriptor(const char *bundle_path, const LV2_Feature *const *features)
 {
-	switch (index) {
-	case 0:
-		return &descriptor;
-	default:
+	char list_path[PATH_SIZE_MAX];
+	snprintf(list_path, sizeof(list_path), "%s" PATH_SEP "soundfonts_list.txt", bundle_path);
+
+	uint32_t number_of_plugins = count_non_empty_lines(list_path);
+	
+	if (0 == number_of_plugins)
+	{
 		return NULL;
 	}
+
+	LV2_Descriptor *library =
+		(LV2_Descriptor *)calloc(number_of_plugins, sizeof(LV2_Descriptor));
+	if (NULL == library)
+	{
+		return NULL;
+	}
+
+	FILE *file = fopen(list_path, "r");
+	if (!file)
+	{
+		free(library);
+		return NULL;
+	}
+
+	char line[PATH_SIZE_MAX];
+    uint32_t index = 0;
+
+	while (fgets(line, sizeof(line), file) && index < number_of_plugins)
+	{
+		trim_whitespaces(line);
+		if (line[0] == '\0')
+		{
+			continue;
+		}
+
+		memcpy(&library[index], &DESCRIPTOR_PROTOTYPE, sizeof(LV2_Descriptor));
+
+		char *uri = malloc(PATH_SIZE_MAX);
+		if (!uri)
+		{
+			fclose(file);
+			free(library);
+			return NULL;
+		}
+		build_plugin_uri(uri, line);
+		library[index].URI = uri;
+
+		index++;
+	}
+
+	fclose(file);
+
+	lib_descriptor.handle = library;
+	lib_descriptor.size = sizeof(LV2_Lib_Descriptor);
+	lib_descriptor.cleanup = library_cleanup;
+	lib_descriptor.get_plugin = library_get_plugin;
+
+	return &lib_descriptor;
 }


### PR DESCRIPTION
## Added feature
The user of the plugin can now install his/her own soundfonts inside the plugin's folder.

## How does it work for the user?
**Setup**
1. User copies his/her soundfonts (.sf2 files) inside the folder `gmsynth.lv2/soundfonts/`
2. User runs the python script `gmsynth.lv2/scan_soundfonts.py`
3. Python sanitize soundfonts filenames and rewrites `manifest.ttl`, `gmsynth.ttl` and `soundfonts_list.txt`
4. User open his/her DAW and performs a plugin rescan.
5. DAW now sees in its library one new plugin for each soundfont installed in this way

**Usage**
After setup the user has 1 plugin for each soundfont named `gmsynth <sounfont_name>`.  
User can load any of these plugins on virtual instrument tracks.

## Coding details
**Python dependency**
The setup and installation now depends on having python on the system.  
I have chosen this method just for speed of development, the Python script can be converted into a C compiled program in order not to have the Python dependency.  
It's just a bit more difficult to perform these tasks in C in a cross-platform way rather than writing a simple Python script.

**Folder structure change**
The default soundfont has been moved to the `gmsynth.lv2/soundfonts/` subdirectory.  
This is just to avoid having a mess of files when the user installs a lot of soundfonts.

**soundfonts_list.txt**
This is for the plugin.  
I needed something easy to read when performing the function lv2_lib_descriptor() in order to avoid a complete directory read in search for all the soundfonts every time the plugin is instantiated.

## Testing
Tested in REAPER daw on Linux Mint.
I compiled it and installed it on my system.
It worked with a rather complex GM file and had the default soundfont "GeneralUser_LV2.sf2" working as usual.  
Then I copied a few of my soundfonts, run the Python script and rescanned for LV2 plugins in REAPER.  
No errors, everything worked as expected.